### PR TITLE
CM-1198-Hebrew-in-notifications

### DIFF
--- a/functions/src/notification/notification.ts
+++ b/functions/src/notification/notification.ts
@@ -104,7 +104,7 @@ export const notifyData: Record<string, IEventData> = {
       notification: async ( {proposalData, commonData, userData} ) => {
           return {
               title: 'A new funding proposal in your Common!',
-              body: `${getNameString(userData)} is asking for $${proposalData.fundingRequest.amount / 100} for their proposal in "${commonData.name}". See the proposal and vote.`,
+              body: `Your fellow member ${getNameString(userData)} is asking for $${proposalData.fundingRequest.amount / 100} for their proposal in "${commonData.name}". See the proposal and vote.`,
               image: commonData.image || '',
               path: `ProposalScreen/${commonData.id}/${proposalData.id}`,
           }
@@ -219,7 +219,7 @@ export const notifyData: Record<string, IEventData> = {
     notification: async ( {sender, commonData, path} ) => (
       {
           title: `New message!`,
-          body: `${getNameString(sender)} commented in "${commonData.name}"`,
+          body: `The member ${getNameString(sender)} commented in "${commonData.name}"`,
           image: commonData.image || '',
           path
       }


### PR DESCRIPTION
I spoke with Tai about this and he provided me with a notification text that will work with Hebrew (basically not having Hebrew in the beginning of the string)
Ticket:
https://daostack1.atlassian.net/jira/software/projects/CM/boards/7?selectedIssue=CM-1198