### PR TITLE
CM-1520 - Notify only for requestToJoinExecuted

### DIFF
--- a/functions/src/notification/notification.ts
+++ b/functions/src/notification/notification.ts
@@ -425,12 +425,6 @@ export const notifyData: Record<string, IEventData> = {
         commonData
       };
     },
-    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    notification: async ({ commonData, subscription }) => (
-      subscription.charges === 1
-        ? memberAddedNotification(commonData)
-        : null
-    ),
     email: ({ subscription, user, card }: {
       subscription: ISubscriptionEntity,
       user: IUserEntity,


### PR DESCRIPTION
Need to check that executing a non-subscription approved request to join is working fine, after Alex's CM-1492 is merged